### PR TITLE
chore(build): use `cargo-chef` to enable caching in docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+recipe.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM rust:1.65.0-slim-bullseye as builder
+# This uses cargo-chef to cache dependencies in order to speed up docker builds.
+#
+# See: https://github.com/LukeMathWalker/cargo-chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.65.0 AS chef
+WORKDIR /app
 
-WORKDIR /usr/src/wohnzimmer
-COPY Cargo.toml Cargo.lock ./
-COPY src/ src/
-RUN cargo install --locked --path .
- 
+## Prepare
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+## Build
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build the dependencies, this is the caching Docker layer.
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build the application.
+COPY . .
+RUN cargo build --release
+
+## Package
 FROM debian:bullseye-slim
-
+COPY --from=builder /app/target/release/wohnzimmer /usr/local/bin/wohnzimmer
 COPY static/ static/
 COPY templates/ templates/
-COPY --from=builder /usr/local/cargo/bin/wohnzimmer /usr/local/bin/wohnzimmer
-
 USER nobody
 EXPOSE 8080
-
-CMD ["wohnzimmer", "--listen-addr", "0.0.0.0:8080"]
+ENTRYPOINT ["/usr/local/bin/wohnzimmer"]
+CMD ["--listen-addr", "0.0.0.0:8080"]


### PR DESCRIPTION
This makes docker layer caching possible and will speed up local image builds already.

For leveraging the caching in GitHub actions, we need to do some updates to the workflows. This will be done separately.