### PR TITLE
chore(release): build and push docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ on:
     branches:
       - main
 
+env:
+  IMAGE_REPO: ghcr.io/musikundkultur/wohnzimmer
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
+      release_tag: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - name: Run release-please
         id: release-please
@@ -26,18 +30,56 @@ jobs:
           package-name: wohnzimmer
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
 
-  deploy:
+  build-image:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-deploy == 'true' }}
     runs-on: ubuntu-latest
     env:
-      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      IMAGE_TAG: ${{ needs.release-please.outputs.release_tag || github.ref_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.IMAGE_TAG }}
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
+            ${{ env.IMAGE_REPO }}:latest
+
+  deploy:
+    needs:
+      - release-please
+      - build-image
+    if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force-deploy == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: ${{ needs.release-please.outputs.release_tag || github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.IMAGE_TAG }}
 
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: flyctl deploy
+        run: flyctl deploy --image ${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Adds a step to the release workflow which automatically builds and pushes a docker image to ghcr.io. The resulting docker image is then deployed via flyctl without rebuilding it.

The GitHub actions docker cache is leveraged to speed up the docker builds.