### PR TITLE
fix(meta): correct team reference in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @musikundkultur
+* @musikundkultur/all


### PR DESCRIPTION
Referencing an organization is invalid, it has to be either a team or a user reference.