### PR TITLE
feat: add hierarchical application config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+/config/local.toml
 /target

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/config/local.toml
 /target
 recipe.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "arc-swap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +343,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -433,40 +439,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "4.0.29"
+name = "config"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
 dependencies = [
- "bitflags",
- "clap_derive",
- "clap_lex",
- "is-terminal",
- "once_cell",
- "strsim",
- "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
-dependencies = [
- "os_str_bytes",
+ "async-trait",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -586,27 +569,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -733,25 +695,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -841,28 +788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,12 +854,6 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "local-channel"
@@ -1023,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +966,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1066,7 +1001,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1075,12 +1010,6 @@ name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1112,6 +1041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,30 +1069,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1249,20 +1160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,9 +1194,23 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_html_form"
@@ -1383,12 +1294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1317,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1498,6 +1423,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1699,11 +1633,14 @@ dependencies = [
  "actix-utils",
  "actix-web",
  "actix-web-lab",
- "clap",
+ "anyhow",
+ "config",
  "env_logger",
  "log",
  "minijinja",
  "minijinja-autoreload",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,11 @@ actix-files = "0.6.2"
 actix-web = "4"
 actix-web-lab = "0.18"
 actix-utils = "3"
-clap = { version = "4.0.29", features = ["derive", "env"] }
+anyhow = "1.0.66"
+config = { version = "0.13.3", default-features = false, features = ["toml"] }
 env_logger = "0.9"
 log = "0.4"
 minijinja = { version = "0.24", features = ["source"] }
 minijinja-autoreload = "0.24"
+serde = { version = "1.0.150", features = ["derive"] }
+thiserror = "1.0.37"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN cargo build --release
 ## Package
 FROM debian:bullseye-slim
 COPY --from=builder /app/target/release/wohnzimmer /usr/local/bin/wohnzimmer
+COPY config/ config/
 COPY static/ static/
 COPY templates/ templates/
 USER nobody
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/wohnzimmer"]
-CMD ["--listen-addr", "0.0.0.0:8080"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,33 @@ This repository contains the source code for the website of the Musik- und
 Kulturförderverein e.V. at [musikundkultur.de](https://musikundkultur.de) /
 [alhambra-luckenwalde.de](https://alhambra-luckenwalde.de).
 
+## Configuration
+
+Configuration is loaded from multiple places in the following order:
+
+1. The file `config/default.toml` is always loaded.
+
+2. If present, the environment specific file `config/{environment}.toml` is
+   loaded based on the value of the `APP_ENV` environment variable, which
+   defaults to `development`.
+
+3. If present, the file `config/local.toml` can be created to override certain
+   configuration values locally (it's on `.gitignore`).
+
+4. Finally, environment variables (with optional `WZ_` prefix) can be set to
+   override any configuration value. E.g. the config `server.listen_addr` can
+   be set via either of these environment variables: `SERVER__LISTEN_ADDR` /
+   `WZ_SERVER__LISTEN_ADDR`.
+
+   **Note**: A double-underscore (`__`) is used as path separator for nested
+   configuration attributes.
+
+### Logging configuration
+
+The log level can be configured via the `RUST_LOG` environment variable.
+Examples can be found in then [`env_logger`
+documentation](https://docs.rs/env_logger/latest/env_logger/).
+
 ## Release process
 
 This project uses

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,20 @@
+[server]
+listen_addr = "127.0.0.1:8080"
+template_autoreload = false
+
+[site]
+title = "Alhambra Luckenwalde"
+tagline = "Musik- und Kulturförderverein e.V."
+description = "Der Musik- und Kulturförderverein e.V. veranstaltet und unterstützt kulturelle Projekte in Luckenwalde und Umgebung, und betreibt im ehemaligen Alhambra Kino am Markt eine Bar."
+
+[[site.links]]
+title = "Instagram"
+href = "https://www.instagram.com/alhambra_luckenwalde"
+
+[[site.links]]
+title = "Facebook"
+href = "https://www.facebook.com/musikundkultur"
+
+[[site.links]]
+title = "Impressum"
+href = "/impressum"

--- a/config/development.toml
+++ b/config/development.toml
@@ -1,0 +1,2 @@
+[server]
+template_autoreload = true

--- a/config/production.toml
+++ b/config/production.toml
@@ -1,0 +1,2 @@
+[server]
+listen_addr = "0.0.0.0:8080"

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ kill_timeout = 5
 processes = []
 
 [env]
+  APP_ENV = "production"
 
 [experimental]
   allowed_public_ports = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,91 @@
+use config::{Config, Environment, File};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::io;
+use std::net::SocketAddr;
+use thiserror::Error;
+
+/// Result type used throughout this crate.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The error type returned by all fallible operations within this crate.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("config error: {0}")]
+    Config(#[from] config::ConfigError),
+}
+
+/// A link configuration.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Link {
+    /// The link title.
+    pub title: String,
+    /// The URL that it points to.
+    pub href: String,
+}
+
+/// Website specific configuration.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct SiteConfig {
+    /// The site title.
+    pub title: String,
+    /// The tagline displayed next to the site title.
+    pub tagline: String,
+    /// Optional site description. This is used in the description meta tag.
+    pub description: Option<String>,
+    /// Links to display in the site footer.
+    pub links: Vec<Link>,
+}
+
+/// Global application configuration.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct ServerConfig {
+    /// Address on which the web server will listen.
+    pub listen_addr: SocketAddr,
+    /// Automatically reload templates when they are modified.
+    pub template_autoreload: bool,
+}
+
+/// Global application configuration.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct AppConfig {
+    /// Server configuration values.
+    pub server: ServerConfig,
+    /// Website configuration values.
+    pub site: SiteConfig,
+}
+
+impl AppConfig {
+    /// Loads the application configuration from files in the `config/` directory and environment
+    /// variables.
+    pub fn load() -> Result<AppConfig> {
+        let app_env = env::var("APP_ENV").unwrap_or_else(|_| "development".into());
+
+        log::info!("loading configuration using {} environment", app_env);
+
+        let config = Config::builder()
+            // Configuration defaults from `config/default.toml`.
+            .add_source(File::with_name("config/default"))
+            // Optional environment specific config overrides, e.g. `config/production.toml`.
+            .add_source(File::with_name(&format!("config/{}", app_env)).required(false))
+            // Optional local config overrides from `config/local.toml` (on .gitignore).
+            .add_source(File::with_name("config/local").required(false))
+            // Config from environment variables.
+            .add_source(Environment::default().separator("__"))
+            // Config from environment variables prefixed with `WZ_`.
+            .add_source(
+                Environment::with_prefix("WZ")
+                    .prefix_separator("_")
+                    .separator("__"),
+            )
+            .build()?
+            .try_deserialize()?;
+
+        log::debug!("loaded configuration: {:?}", config);
+
+        Ok(config)
+    }
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -13,35 +13,31 @@
   <meta name="msapplication-config" content="/static/browserconfig.xml">
   <meta name="theme-color" content="#c21e1d">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Der Musik- und Kulturförderverein e.V. veranstaltet und unterstützt kulturelle Projekte in Luckenwalde und Umgebung, und betreibt im ehemaligen Alhambra Kino am Markt eine Bar.">
+{%- if config.site.description %}
+  <meta name="description" content="{{ config.site.description }}">
+{%- endif %}
   <meta charset="utf-8" />
-  <title>
-    {% block title %}Alhambra Luckenwalde | Musik- und Kulturförderverein e.V.{% endblock %}
-  </title>
+  <title>{% block title %}{{ config.site.title }} | {{ config.site.tagline }}{% endblock %}</title>
 </head>
 <body class="{% block body_class %}boxed{% endblock %}">
   {% block body %}
   <div class="container">
     <div class="header">
       <h1>
-        <a href="/" rel="home">Alhambra Luckenwalde</a>
+        <a href="/" rel="home">{{ config.site.title }}</a>
       </h1>
-      <h2>Musik- und Kulturförderverein e.V.</h2>
+      <h2>{{ config.site.tagline }}</h2>
     </div>
     <div class="content">
       {% block content %}{% endblock %}
     </div>
     <div class="footer">
       <ul>
+        {%- for link in config.site.links %}
         <li>
-          <a href="https://www.instagram.com/alhambra_luckenwalde">Instagram</a>
+          <a href="{{ link.href }}">{{ link.title }}</a>
         </li>
-        <li>
-          <a href="https://www.facebook.com/musikundkultur">Facebook</a>
-        </li>
-        <li>
-          <a href="/impressum">Impressum</a>
-        </li>
+        {%- endfor %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Makes use of [`config-rs`](https://github.com/mehcode/config-rs) to implement hierarchical configuration from files and environment variables. This makes `clap` obsolete.

In the future we'll have more configuration options, e.g. when we add calendar support for events. Also we need to be able to configure things canonical URLs (for SEO) which are only relevant in production.