### PR TITLE
feat(calendar): add `EventSource` abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -188,7 +189,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time",
+ "time 0.3.17",
  "url",
 ]
 
@@ -309,6 +310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +455,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "pure-rust-locales",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa48fa079165080f11d7753fd0bc175b7d391f276b965fe4b55bfad67856e463"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,9 +530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
 dependencies = [
  "percent-encoding",
- "time",
+ "time 0.3.17",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -517,6 +588,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -666,7 +781,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -748,6 +863,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +904,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -818,6 +958,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +1003,15 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "local-channel"
@@ -964,7 +1122,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -993,6 +1151,25 @@ dependencies = [
  "mio",
  "walkdir",
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1035,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1237,44 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1078,6 +1302,12 @@ checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pure-rust-locales"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45c49fc4f91f35bae654f85ebb3a44d60ac64f11b3166ffa609def390c732d8"
 
 [[package]]
 name = "quote"
@@ -1181,6 +1411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "self_cell"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1579,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1504,6 +1757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,9 +1792,69 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"
@@ -1630,12 +1949,17 @@ name = "wohnzimmer"
 version = "0.1.3"
 dependencies = [
  "actix-files",
+ "actix-rt",
  "actix-utils",
  "actix-web",
  "actix-web-lab",
  "anyhow",
+ "async-trait",
+ "chrono",
+ "chrono-tz",
  "config",
  "env_logger",
+ "indexmap",
  "log",
  "minijinja",
  "minijinja-autoreload",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,17 @@ actix-web = "4"
 actix-web-lab = "0.18"
 actix-utils = "3"
 anyhow = "1.0.66"
+async-trait = "0.1.59"
 config = { version = "0.13.3", default-features = false, features = ["toml"] }
+chrono = { version = "0.4.23", features = ["serde", "unstable-locales"] }
+chrono-tz = "0.8.1"
 env_logger = "0.9"
+indexmap = { version = "1.9.2", features = ["serde"] }
 log = "0.4"
 minijinja = { version = "0.24", features = ["source"] }
 minijinja-autoreload = "0.24"
 serde = { version = "1.0.150", features = ["derive"] }
 thiserror = "1.0.37"
+
+[dev-dependencies]
+actix-rt = "2.7.0"

--- a/config/default.toml
+++ b/config/default.toml
@@ -18,3 +18,18 @@ href = "https://www.facebook.com/musikundkultur"
 [[site.links]]
 title = "Impressum"
 href = "/impressum"
+
+[calendar]
+# This can also be set to `google-calendar` in the production config once
+# support for it is implemented.
+event_source = "static"
+
+# List of events used by the `static` event source.
+events = [
+    { date = "2022-10-28T19:00:00+01:00", title = "Halloween-Party" },
+    { date = "2022-11-04T19:00:00+01:00", title = "Geschlossene Gesellschaft" },
+    { date = "2022-11-18T19:00:00+01:00", title = "Kneipenquiz" },
+    { date = "2022-12-02T19:00:00+01:00", title = "Vorverkaufsparty Weihnachtskonzert" },
+    { date = "2022-12-09T19:00:00+01:00", title = "Lesung" },
+    { date = "2022-12-25T19:00:00+01:00", title = "Weihnachtskonzert" }
+]

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -1,0 +1,207 @@
+use super::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Datelike, Locale, Utc};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use std::ops::Range;
+
+/// Type alias for a date represented in UTC.
+pub type UtcDate = DateTime<Utc>;
+
+/// Represents a single calendar event.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    /// The date of the event.
+    #[serde(serialize_with = "serialize_german_date")]
+    pub date: UtcDate,
+    /// The event title.
+    pub title: String,
+}
+
+/// Type alias for calendar events grouped by year.
+pub type EventsByYear = IndexMap<i32, Vec<Event>>;
+
+/// Represents sources of calendar events.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum EventSourceKind {
+    /// Use static events from the application configuration.
+    Static,
+    /// Load events from Google Calendar.
+    GoogleCalendar,
+}
+
+/// Trait that needs to be implemented by a source of calendar events.
+#[async_trait]
+pub trait EventSource: Send + Sync {
+    /// Filters events between a start date (inclusive) and an end date (exclusive).
+    async fn get_events(&self, range: Range<UtcDate>) -> Result<Vec<Event>>;
+}
+
+/// An `EventSource` that returns events from a static list.
+pub struct StaticEventSource {
+    events: Vec<Event>,
+}
+
+impl StaticEventSource {
+    /// Creates a new `StaticEventSource` from an iterator.
+    pub fn new<I>(iter: I) -> StaticEventSource
+    where
+        I: IntoIterator,
+        I::Item: Into<Event>,
+    {
+        let mut events: Vec<Event> = iter.into_iter().map(Into::into).collect();
+        // Ensure events are always sorted by date.
+        events.sort_by_key(|event| event.date);
+
+        StaticEventSource { events }
+    }
+}
+
+#[async_trait]
+impl EventSource for StaticEventSource {
+    async fn get_events(&self, range: Range<UtcDate>) -> Result<Vec<Event>> {
+        let events = self
+            .events
+            .iter()
+            .filter(|event| range.contains(&event.date))
+            .cloned()
+            .collect();
+
+        Ok(events)
+    }
+}
+
+/// The `Calendar` type wraps an event source with additional functionality.
+pub struct Calendar {
+    event_source: Box<dyn EventSource + 'static>,
+}
+
+impl Calendar {
+    /// Creates a new `Calendar` from an event source.
+    pub fn new<T>(event_source: T) -> Calendar
+    where
+        T: EventSource + 'static,
+    {
+        Calendar {
+            event_source: Box::new(event_source),
+        }
+    }
+
+    /// Filters events between a start date (inclusive) and an end date (exclusive).
+    pub async fn get_events(&self, range: Range<UtcDate>) -> Result<Vec<Event>> {
+        self.event_source.get_events(range).await
+    }
+
+    /// Builds an index of event year to list of events. This is used to avoid having complicated
+    /// logic for displaying events by year in HTML templates.
+    pub async fn get_events_by_year(&self, range: Range<UtcDate>) -> Result<EventsByYear> {
+        let events = self.get_events(range).await?;
+        let mut events_by_year: EventsByYear = IndexMap::new();
+
+        events.into_iter().for_each(|event| {
+            events_by_year
+                .entry(event.date.year())
+                .or_default()
+                .push(event);
+        });
+
+        Ok(events_by_year)
+    }
+}
+
+/// Serializes a date as `%e. %B` using german as locale, e.g. `13. Dezember`. This is used by
+/// minijinja in templates. The year display is handled by other means in the HTML template.
+fn serialize_german_date<S>(date: &UtcDate, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let s = date
+        .with_timezone(&chrono_tz::CET)
+        .format_localized("%e. %B", Locale::de_DE)
+        .to_string();
+    serializer.serialize_str(&s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use indexmap::indexmap;
+
+    macro_rules! date {
+        ($y:expr, $m:expr, $d:expr) => {
+            Utc.with_ymd_and_hms($y, $m, $d, 0, 0, 0).unwrap()
+        };
+    }
+
+    macro_rules! event {
+        ($title:expr, $y:expr, $m:expr, $d:expr) => {
+            Event {
+                title: $title.into(),
+                date: date!($y, $m, $d),
+            }
+        };
+    }
+
+    #[actix_rt::test]
+    async fn events_between() {
+        let calendar = Calendar::new(StaticEventSource::new([
+            event!("a", 2022, 12, 30),
+            event!("b", 2022, 12, 31),
+            event!("c", 2023, 1, 1),
+            event!("d", 2023, 1, 2),
+            event!("e", 2023, 1, 1),
+        ]));
+
+        assert_eq!(
+            calendar
+                .get_events(date!(2022, 12, 31)..date!(2023, 1, 2))
+                .await
+                .unwrap(),
+            vec![
+                event!("b", 2022, 12, 31),
+                event!("c", 2023, 1, 1),
+                event!("e", 2023, 1, 1)
+            ]
+        );
+        assert_eq!(
+            calendar
+                .get_events(date!(2022, 12, 31)..date!(2023, 1, 1))
+                .await
+                .unwrap(),
+            vec![event!("b", 2022, 12, 31)]
+        );
+    }
+
+    #[actix_rt::test]
+    async fn events_by_year() {
+        let calendar = Calendar::new(StaticEventSource::new([
+            event!("a", 2022, 12, 30),
+            event!("b", 2022, 12, 31),
+            event!("c", 2023, 1, 1),
+            event!("d", 2023, 1, 2),
+            event!("e", 2023, 1, 1),
+        ]));
+
+        let expected = indexmap! {
+            2022 => vec![
+                event!("a", 2022, 12, 30),
+                event!("b", 2022, 12, 31),
+            ],
+            2023 => vec![
+                event!("c", 2023, 1, 1),
+                event!("e", 2023, 1, 1),
+                event!("d", 2023, 1, 2),
+            ]
+        };
+
+        assert_eq!(
+            calendar
+                .get_events_by_year(date!(2022, 1, 1)..date!(2023, 12, 31))
+                .await
+                .unwrap(),
+            expected
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::net::SocketAddr;
 use thiserror::Error;
 
+pub mod calendar;
+
 /// Result type used throughout this crate.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -27,6 +29,16 @@ pub struct Link {
     pub href: String,
 }
 
+/// Calendar configuration.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct CalendarConfig {
+    /// Source for calendar events.
+    pub event_source: calendar::EventSourceKind,
+    /// Mapping of event date to event title.
+    #[serde(default)]
+    pub events: Vec<calendar::Event>,
+}
+
 /// Website specific configuration.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct SiteConfig {
@@ -37,6 +49,7 @@ pub struct SiteConfig {
     /// Optional site description. This is used in the description meta tag.
     pub description: Option<String>,
     /// Links to display in the site footer.
+    #[serde(default)]
     pub links: Vec<Link>,
 }
 
@@ -52,10 +65,12 @@ pub struct ServerConfig {
 /// Global application configuration.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct AppConfig {
-    /// Server configuration values.
+    /// Server configuration section.
     pub server: ServerConfig,
-    /// Website configuration values.
+    /// Website configuration section.
     pub site: SiteConfig,
+    /// Calendar configuration section.
+    pub calendar: CalendarConfig,
 }
 
 impl AppConfig {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,32 +7,16 @@
     <a href="https://www.facebook.com/musikundkultur" title="Alhambra Luckenwalde auf Facebook">Reinspaziert</a>
   </div>
   <div class="events">
-    <h3>Termine 2022</h3>
-    <table summary="Termine 2022">
+    {% for year, events in events_by_year | items %}
+    <h3>Termine {{ year }}</h3>
+    <table summary="Termine {{ year }}">
+      {% for event in events %}
       <tr>
-        <th>28. Oktober</th>
-        <td>Halloween-Party</td>
+        <th>{{ event.date }}</th>
+        <td>{{ event.title }}</td>
       </tr>
-      <tr>
-        <th>4. November</th>
-        <td>Geschlossene Gesellschaft</td>
-      </tr>
-      <tr>
-        <th>18. November</th>
-        <td>Kneipenquiz</td>
-      </tr>
-      <tr>
-        <th>2. Dezember</th>
-        <td>Vorverkaufsparty Weihnachtskonzert</td>
-      </tr>
-      <tr>
-        <th>9. Dezember</th>
-        <td>Lesung</td>
-      </tr>
-      <tr>
-        <th>25. Dezember</th>
-        <td>Weihnachtskonzert</td>
-      </tr>
+      {% endfor %}
     </table>
+    {% endfor %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Adds an `EventSource` trait which allows the implementation of multiple sources for calendar events.

Right now only `StaticEventSource` was implemented to use a static list of events from the config. This is mostly useful during testing and development.

Later, we want to also add an `EventSource` for the Google Calendar which should be used in production.

Please note that the API for the `EventSource` trait is just an initial draft. We can obviously change it once we see what's needed by Google Calendar. I already designed it to be `async` though, because we'll need that later.