### PR TITLE
chore: add support for canonical `link` tag

### DIFF
--- a/config/production.toml
+++ b/config/production.toml
@@ -1,2 +1,5 @@
 [server]
 listen_addr = "0.0.0.0:8080"
+
+[site]
+canonical_url = "https://alhambra-luckenwalde.de"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub struct SiteConfig {
     pub tagline: String,
     /// Optional site description. This is used in the description meta tag.
     pub description: Option<String>,
+    /// Optional canonical URL of the site. This is used in the canonical meta tag.
+    pub canonical_url: Option<String>,
     /// Links to display in the site footer.
     #[serde(default)]
     pub links: Vec<Link>,

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,6 +16,9 @@
 {%- if config.site.description %}
   <meta name="description" content="{{ config.site.description }}">
 {%- endif %}
+{%- if config.site.canonical_url and request_path %}
+  <link rel="canonical" href="{{ config.site.canonical_url }}{{ request_path }}">
+{%- endif %}
   <meta charset="utf-8" />
   <title>{% block title %}{{ config.site.title }} | {{ config.site.tagline }}{% endblock %}</title>
 </head>


### PR DESCRIPTION
If a `canonical_url` is configured in the `site` config, the `link` tag with the canonical URL will be added to the HTML head.

This is only relevant for SEO, here's what Google has to say about this: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls

I don't like the way we pass down the `request_path` into the template. In the best case I'd like to have this done implicitly somehow. Otherwise we will need to do this for every endpoint and it's easy to forget.