### PR TITLE
feat(events): fetch Google Calendar events in the background

### DIFF
--- a/src/calendar/google/mod.rs
+++ b/src/calendar/google/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 pub type DateRange = Range<DateTime<Utc>>;
 
 /// Google calendar client for making requests to the google calendar api
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GoogleCalendarClient {
     client: ClientWithMiddleware,
     calendar_id: String,


### PR DESCRIPTION
Fetching events via Google Calendar API is slow and takes ~3 seconds. This negatively impacts page load performance.

This moves the heavy event fetching into a background task which is triggered when the homepage is visited, updating the event cache for the next page load. This makes all page loads very fast, except for the first one right after the application starts since it needs to populate the event cache in the foreground.