### PR TITLE
chore(deps): bump google-cloud-auth from 0.6.1 to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.20",
+ "time",
  "url",
 ]
 
@@ -488,13 +488,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "pure-rust-locales",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -557,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.20",
+ "time",
  "version_check",
 ]
 
@@ -933,25 +930,26 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.6.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d626e8a47a8d596bc53a4f48e0a97f11e2f706279976054fb1115587d01a1e"
+checksum = "03adc2c203a6eaa0c45620a5fbc7b1bf6616111c1eaff913669e2a3c26ffe1b9"
 dependencies = [
  "async-trait",
- "base64 0.13.1",
- "chrono",
+ "base64 0.21.0",
  "google-cloud-metadata",
+ "google-cloud-token",
  "home",
  "jsonwebtoken",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "urlencoding",
@@ -959,13 +957,22 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-metadata"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2c3b00f0a07a1a9efffc1bdd0603ef853d8a6d4ee9de8d73039cd92fdc8f26"
+checksum = "96e4ad0802d3f416f62e7ce01ac1460898ee0efc98f8b45cd4aab7611607012f"
 dependencies = [
  "reqwest",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9fa5c241ab09d3531496127ef107a29cc2a8fde63676f7cbbe56a8a5e75883"
+dependencies = [
+ "async-trait",
 ]
 
 [[package]]
@@ -1436,7 +1443,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -2034,7 +2041,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -2151,17 +2158,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.4",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2414,12 +2410,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2648,6 +2638,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "google-cloud-auth",
+ "google-cloud-token",
  "indexmap",
  "log",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ minijinja-autoreload = "0.27"
 serde = { version = "1.0.150", features = ["derive"] }
 thiserror = "1.0.38"
 serde_json = "1"
-google-cloud-auth = "0.6.1"
+google-cloud-auth = "0.9.1"
+google-cloud-token = "0.1.0"
 reqwest = { version = "0.11", features = ["json"] }
 reqwest-middleware = "0.2.0"
 task-local-extensions = "0.1.3"

--- a/examples/calendar-example.rs
+++ b/examples/calendar-example.rs
@@ -3,7 +3,6 @@ extern crate dotenv;
 use chrono::{Months, Utc};
 use dotenv::dotenv;
 use std::error::Error;
-
 use wohnzimmer::calendar::{Calendar, GoogleCalendarEventSource};
 
 #[tokio::main]
@@ -11,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     dotenv().ok();
 
-    let calendar = Calendar::new(GoogleCalendarEventSource::new()?);
+    let calendar = Calendar::new(GoogleCalendarEventSource::new().await?);
 
     let now = Utc::now();
     let one_month_ago = now - Months::new(1);

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -87,9 +87,9 @@ pub struct GoogleCalendarEventSource {
 }
 
 impl GoogleCalendarEventSource {
-    pub fn new() -> Result<Self> {
-        Ok(Self {
-            client: GoogleCalendarClient::new(None)?,
+    pub async fn new() -> Result<GoogleCalendarEventSource> {
+        Ok(GoogleCalendarEventSource {
+            client: GoogleCalendarClient::new().await?,
         })
     }
 }
@@ -270,10 +270,10 @@ impl Calendar {
     }
 
     /// Creates a new `Calendar` from configuration.
-    pub fn from_config(config: &CalendarConfig) -> Result<Calendar> {
+    pub async fn from_config(config: &CalendarConfig) -> Result<Calendar> {
         let event_source: Box<dyn EventSource> = match config.event_source {
             EventSourceKind::Static => Box::new(StaticEventSource::new(config.events.clone())),
-            EventSourceKind::GoogleCalendar => Box::new(GoogleCalendarEventSource::new()?),
+            EventSourceKind::GoogleCalendar => Box::new(GoogleCalendarEventSource::new().await?),
         };
 
         let calendar = if config.cache.enabled {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
 
     let config = AppConfig::load()?;
 
-    let calendar = Calendar::from_config(&config.calendar)?;
+    let calendar = Calendar::from_config(&config.calendar).await?;
 
     if config.server.template_autoreload {
         log::info!("template auto-reloading is enabled");


### PR DESCRIPTION
This manually performs the version bump proposed by dependabot in https://github.com/musikundkultur/wohnzimmer/pull/43 because there were so many breaking changes that needed to be resolved manually.

Main changes:

- We don't need to manually handle token refresh anymore because the `TokenSource` does this transparently for us.
- Remove the `calendar_id` argument from the `GoogleCalendarClient` constructor since we always pull it from env at the moment.
- Some methods were converted to be `async` because of async dependencies.
- `ClientError` variants and messages were improved according to best practices (e.g. removed verbose `Error` suffix).

Closes #43.