### PR TITLE
feat(calendar): switch to periodic sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,12 +349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_once"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,43 +422,6 @@ checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
 dependencies = [
  "bytes",
 ]
-
-[[package]]
-name = "cached"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6d20b3d24b6c74e2c5331d2d3d8d1976a9883c7da179aa851afa4c90d62e36"
-dependencies = [
- "async-trait",
- "async_once",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown",
- "instant",
- "lazy_static",
- "once_cell",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
-dependencies = [
- "cached_proc_macro_types",
- "darling",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -668,41 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,27 +773,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -879,12 +786,6 @@ name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-io"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-sink"
@@ -905,7 +806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
- "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1136,12 +1036,6 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2082,12 +1976,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,7 +2519,6 @@ dependencies = [
  "actix-web-lab",
  "anyhow",
  "async-trait",
- "cached",
  "chrono",
  "chrono-tz",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ actix-web-lab = "0.18"
 actix-utils = "3"
 anyhow = "1.0.66"
 async-trait = "0.1.64"
-cached = "0.41.0"
 config = { version = "0.13.3", default-features = false, features = ["toml"] }
 chrono = { version = "0.4.23", default-features = false, features = ["clock", "serde", "std", "unstable-locales"] }
 chrono-tz = "0.8.1"

--- a/config/default.toml
+++ b/config/default.toml
@@ -52,7 +52,3 @@ events = [
     { date = "2023-04-28T18:00:00+01:00", title = "Kneipenquiz" },
     { date = "2023-04-29T18:00:00+01:00", title = "Geschlossene Gesellschaft" },
 ]
-
-[calendar.cache]
-enabled = false
-ttl_seconds = 60

--- a/config/production.toml
+++ b/config/production.toml
@@ -6,6 +6,4 @@ canonical_url = "https://alhambra-luckenwalde.de"
 
 [calendar]
 event_source = "google-calendar"
-
-[calendar.cache]
-enabled = true
+sync_period_seconds = 300

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,17 +39,8 @@ pub struct CalendarConfig {
     /// Mapping of event date to event title.
     #[serde(default)]
     pub events: Vec<calendar::Event>,
-    /// Calendar cache configuration section.
-    pub cache: CalendarCacheConfig,
-}
-
-/// Calendar cache configuration.
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub struct CalendarCacheConfig {
-    /// If `true`, calendar events will be cached.
-    pub enabled: bool,
-    /// Cache TTL in seconds before re-fetching calendar events from the source.
-    pub ttl_seconds: Option<u64>,
+    /// Period for calendar synchronization.
+    pub sync_period_seconds: Option<u64>,
 }
 
 /// Website specific configuration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,10 @@ use actix_web_lab::respond::Html;
 use chrono::{Duration, DurationRound, Months, Utc};
 use minijinja::value::Value;
 use minijinja_autoreload::AutoReloader;
+use std::sync::Arc;
+use tokio::time;
 use wohnzimmer::{
-    calendar::{Calendar, EventsByYear},
+    calendar::{self, Calendar, EventsByYear},
     AppConfig,
 };
 
@@ -92,7 +94,10 @@ async fn main() -> anyhow::Result<()> {
 
     let config = AppConfig::load()?;
 
-    let calendar = Calendar::from_config(&config.calendar).await?;
+    let calendar = Arc::new(Calendar::from_config(&config.calendar).await?);
+
+    let period = time::Duration::from_secs(config.calendar.sync_period_seconds.unwrap_or(60));
+    let (stop_tx, done_rx) = calendar::spawn_sync_task(calendar.clone(), period).await;
 
     if config.server.template_autoreload {
         log::info!("template auto-reloading is enabled");
@@ -118,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
         Ok(env)
     });
 
-    let calendar = Data::new(calendar);
+    let calendar = Data::from(calendar);
     let tmpl_reloader = Data::new(tmpl_reloader);
 
     log::info!("starting HTTP server at {}", config.server.listen_addr);
@@ -144,6 +149,17 @@ async fn main() -> anyhow::Result<()> {
     .bind(config.server.listen_addr)?
     .run()
     .await?;
+
+    // Graceful shutdown of calendar sync.
+    match stop_tx.send(()) {
+        Ok(_) => {
+            // Wait for the calendar sync to be stopped.
+            let _ = done_rx.await;
+        }
+        Err(_) => {
+            log::error!("failed to stop calendar sync");
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
We're periodically fetching all events from the event source instead of smaller ranges. This makes quite a bit of code and the whole caching layer obsolete.

It also avoids the first request to the homepage on a given day from taking too long, because there's no such thing as cache misses anymore.