### PR TITLE
feat: add `events` pages and limit event display on homepage

### DIFF
--- a/templates/events.html
+++ b/templates/events.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+
+{% block body_class %}events{% endblock %}
+
+{% block content %}
+  {% block before_events %}{% endblock %}
+  <div class="events">
+    {% for year, events in events_by_year | items %}
+    <h3>Termine {{ year }}</h3>
+    <table summary="Termine {{ year }}">
+      {% for event in events %}
+      <tr>
+        <th>{{ event.date }}</th>
+        <td>{{ event.title }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    {% endfor %}
+  </div>
+  {% block after_events %}{% endblock %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,22 +1,15 @@
-{% extends "layout.html" %}
+{% extends "events.html" %}
 
 {% block body_class %}index{% endblock %}
 
-{% block content %}
-  <div class="doors">
-    <a href="https://www.facebook.com/musikundkultur" title="Alhambra Luckenwalde auf Facebook">Reinspaziert</a>
-  </div>
-  <div class="events">
-    {% for year, events in events_by_year | items %}
-    <h3>Termine {{ year }}</h3>
-    <table summary="Termine {{ year }}">
-      {% for event in events %}
-      <tr>
-        <th>{{ event.date }}</th>
-        <td>{{ event.title }}</td>
-      </tr>
-      {% endfor %}
-    </table>
-    {% endfor %}
-  </div>
+{% block before_events %}
+<div class="doors">
+  <a href="https://www.facebook.com/musikundkultur" title="Alhambra Luckenwalde auf Facebook">Reinspaziert</a>
+</div>
+{% endblock %}
+
+{% block after_events %}
+<p>
+  <a href="/events">Alle Termine</a>
+</p>
 {% endblock %}


### PR DESCRIPTION
The newly added `/events` page will display all upcoming events from the next 12 months, while on the homepage we now only display events for the next 3 months and add a link to the events page, so users can discover the longer list if they need.

Also, we do not display events of the past month anymore because it was useless and confusing.