### PR TITLE
ci: always deploy application on tags and pushes to main

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,5 +1,5 @@
 ---
-name: Build Image
+name: container
 
 on:
   workflow_dispatch:
@@ -14,12 +14,17 @@ on:
 
 permissions: read-all
 
+env:
+  IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/wohnzimmer
+
 jobs:
   build-image:
     permissions:
       packages: write
       contents: read
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +33,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/wohnzimmer
+          images: |
+            ${{ env.IMAGE_REPO }}
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
@@ -39,9 +45,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    needs:
+      - build-image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        run: flyctl deploy --image ${{ env.IMAGE_REPO }}@${{ needs.build-image.outputs.digest }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
This simplifies the release process and also makes rollbacks easier.

The release process docs in README.md need to be adjusted, but I'd like to postpone this until I'm done with the restructuring because there will be more PRs related to that.