### PR TITLE
feat: switch from chrono to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,21 +262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,41 +456,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "pure-rust-locales",
- "serde",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
-dependencies = [
- "parse-zoneinfo",
- "phf_codegen",
-]
 
 [[package]]
 name = "colorchoice"
@@ -1044,29 +994,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1051,32 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jiff"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a46169c7a10358cdccfb179910e8a5a392fc291bdb409da9aeece5b19786d8"
+dependencies = [
+ "jiff-tzdb-platform",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -1469,15 +1422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,44 +1448,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1581,12 +1487,6 @@ checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "pure-rust-locales"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190fd18ae6ce9e137184f207593877e70f39b015040156b1e05081cdfe3733a"
 
 [[package]]
 name = "quote"
@@ -1963,12 +1863,6 @@ dependencies = [
  "thiserror 1.0.65",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -2535,15 +2429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,8 +2682,6 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
- "chrono",
- "chrono-tz",
  "config",
  "dotenv",
  "env_logger",
@@ -2806,6 +2689,7 @@ dependencies = [
  "google-cloud-token",
  "http 1.2.0",
  "indexmap",
+ "jiff",
  "log",
  "minijinja",
  "minijinja-autoreload",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ actix-utils = "3"
 anyhow = "1.0.95"
 async-trait = "0.1.83"
 config = { version = "0.15.4", default-features = false, features = ["toml"] }
-chrono = { version = "0.4.39", default-features = false, features = ["clock", "serde", "std", "unstable-locales"] }
-chrono-tz = "0.10.0"
 env_logger = "0.11"
 indexmap = { version = "2.7.0", features = ["serde"] }
 log = "0.4"
@@ -34,6 +32,7 @@ reqwest = { version = "0.12", features = ["gzip", "json"] }
 reqwest-middleware = "0.4"
 http = "1.2"
 tokio = { version = "1.42.0", features = ["full"] }
+jiff = { version = "0.1.16", features = ["serde"] }
 
 [dev-dependencies]
 actix-rt = "2.10.0"

--- a/examples/calendar-example.rs
+++ b/examples/calendar-example.rs
@@ -1,7 +1,7 @@
 extern crate dotenv;
 
-use chrono::{Months, Utc};
 use dotenv::dotenv;
+use jiff::{ToSpan, Zoned};
 use std::error::Error;
 use wohnzimmer::calendar::{Calendar, GoogleCalendarEventSource};
 
@@ -13,12 +13,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let calendar = Calendar::new(GoogleCalendarEventSource::new().await?);
     calendar.sync_once().await?;
 
-    let now = Utc::now();
-    let one_month_ago = now - Months::new(1);
-    let in_six_months = now + Months::new(6);
+    let now = Zoned::now();
+    let start = &now - 1.months();
+    let end = &now + 6.months();
 
     let events_by_year = calendar
-        .get_events_by_year(one_month_ago..in_six_months)
+        .get_events_by_year(start.timestamp()..end.timestamp())
         .await?;
 
     println!("{:#?}", events_by_year);

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ processes = []
 
 [env]
   APP_ENV = "production"
+  TZ = "Europe/Berlin"
 
 [experimental]
   allowed_public_ports = []

--- a/src/calendar/templating.rs
+++ b/src/calendar/templating.rs
@@ -1,46 +1,62 @@
 use super::Event;
-use chrono::Locale;
+use jiff::{tz::TimeZone, SignedDuration, Zoned};
 use minijinja::value::{Object, Value};
 use std::sync::Arc;
 
 impl Object for Event {
     fn get_value(self: &Arc<Self>, field: &Value) -> Option<Value> {
+        let start_date = self.start_date.to_zoned(TimeZone::system());
+
         let value = match field.as_str()? {
-            "date" => {
-                let start_date = self
-                    .start_date
-                    .with_timezone(&chrono_tz::CET)
-                    .format_localized("%e. %B", Locale::de_DE);
-
-                Value::from(format!("{start_date}"))
-            }
+            "date" => Value::from(german_date(&start_date)),
             "time" => {
-                let start_time = self
-                    .start_date
-                    .with_timezone(&chrono_tz::CET)
-                    .format("%k:%M");
+                let start_time = start_date.strftime("%H:%M");
+                let one_day = SignedDuration::from_hours(24);
 
-                match self.end_date {
-                    Some(end_date) => {
-                        let end_date = if self.start_date.date_naive() == end_date.date_naive() {
-                            // Single-day event, just format the end time.
-                            end_date.with_timezone(&chrono_tz::CET).format("%k:%M")
-                        } else {
-                            // Multi-day event, format end date and time.
-                            end_date
-                                .with_timezone(&chrono_tz::CET)
-                                .format_localized("%e. %B %k:%M", Locale::de_DE)
-                        };
-
-                        Value::from(format!("{start_time} - {end_date}"))
+                let formatted = match self.end_date.map(|ts| ts.to_zoned(TimeZone::system())) {
+                    Some(end_date) if start_date.duration_until(&end_date) > one_day => {
+                        // More than 24h between start and end date, format end date and time.
+                        format!(
+                            "{start_time} - {} {}",
+                            german_date(&end_date),
+                            end_date.strftime("%H:%M")
+                        )
                     }
-                    None => Value::from(format!("{start_time}")),
-                }
+                    Some(end_date) => {
+                        // Less than 24h between start and end date, just format the end time.
+                        format!("{start_time} - {}", end_date.strftime("%H:%M"))
+                    }
+                    None => format!("{start_time}"),
+                };
+
+                Value::from(formatted)
             }
             "title" => Value::from(self.title.clone()),
             _ => return None,
         };
 
         Some(value)
+    }
+}
+
+fn german_date(date: &Zoned) -> String {
+    format!("{}. {}", date.strftime("%e"), german_month_name(date))
+}
+
+fn german_month_name(date: &Zoned) -> &'static str {
+    match date.month() {
+        1 => "Januar",
+        2 => "Februar",
+        3 => "März",
+        4 => "April",
+        5 => "Mai",
+        6 => "Juni",
+        7 => "Juli",
+        8 => "August",
+        9 => "September",
+        10 => "Oktober",
+        11 => "November",
+        12 => "Dezember",
+        _ => unreachable!("month can only be in range 1..=12"),
     }
 }


### PR DESCRIPTION
First of all, jiff has a nicer to work with API, and second, this makes it harded to make mistakes when working with zoned timestamps.

It also gets rid of some transitive dependencies and forces the correct timezone for the container to avoid running into surprises.
