### PR TITLE
ci: use separate deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
 ---
 name: ci
+
 on:
   pull_request:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+env:
+  IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/wohnzimmer
 
 jobs:
   test:
@@ -90,7 +100,7 @@ jobs:
         run: cargo clippy
 
   docs:
-    name: Docs
+    name: docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -107,3 +117,28 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --document-private-items --workspace --all-features
+
+  build-image:
+    if: github.event_name == 'pull_request'
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.IMAGE_REPO }}
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 ---
-name: container
+name: deploy
 
 on:
   workflow_dispatch:
@@ -8,9 +8,10 @@ on:
       - main
     tags:
       - v*
-  pull_request:
-    branches:
-      - main
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
 
 permissions: read-all
 
@@ -37,7 +38,6 @@ jobs:
             ${{ env.IMAGE_REPO }}
 
       - name: Login to ghcr.io
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -49,14 +49,13 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
   deploy:
     needs:
       - build-image
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This fixes some concurrency issues when multiple PR are merged and the deploy job is triggered in parallel, leading to fly.io errors because of a parallel deployment.

By splitting these workflows, we can leverage the `concurrency` config to ensure there's only one run of the deploy workflow at any given time. Additionally, we now also limit job concurrency at a PR level so that multiple quick pushes result in fewer job runs.