### PR TITLE
feat: add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-httpauth"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456348ed9dcd72a13a1f4a660449fafdecee9ac8205552e286809eb5b0b29bd3"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "base64 0.22.0",
+ "futures-core",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web-prom"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a34f1825c3ae06567a9d632466809bbf34963c86002e8921b64f32d48d289d"
+dependencies = [
+ "actix-web",
+ "futures-core",
+ "log",
+ "pin-project-lite",
+ "prometheus",
+ "regex",
+ "strfmt",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
@@ -706,9 +736,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -726,6 +756,7 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -842,6 +873,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -1507,6 +1544,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.5.0",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.5.0",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1995,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strfmt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
 
 [[package]]
 name = "subtle"
@@ -2698,6 +2787,8 @@ dependencies = [
  "actix-rt",
  "actix-utils",
  "actix-web",
+ "actix-web-httpauth",
+ "actix-web-prom",
  "anyhow",
  "async-trait",
  "config",
@@ -2711,6 +2802,7 @@ dependencies = [
  "log",
  "minijinja",
  "minijinja-autoreload",
+ "prometheus",
  "reqwest",
  "reqwest-middleware",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ reqwest-middleware = "0.4"
 http = "1.2"
 tokio = { version = "1.42.0", features = ["full"] }
 jiff = { version = "0.1.16", features = ["serde"] }
+actix-web-httpauth = "0.8.2"
+actix-web-prom = "0.9.0"
+prometheus = { version = "0.13.4", features = ["process"] }
 
 [dev-dependencies]
 actix-rt = "2.10.0"

--- a/config/default.toml
+++ b/config/default.toml
@@ -2,6 +2,9 @@
 listen_addr = "127.0.0.1:8080"
 template_autoreload = false
 
+[metrics]
+enabled = false
+
 [site]
 title = "Alhambra Luckenwalde"
 tagline = "Musik- und Kulturförderverein e.V."

--- a/config/development.toml
+++ b/config/development.toml
@@ -1,2 +1,5 @@
 [server]
 template_autoreload = true
+
+[metrics]
+enabled = true

--- a/examples/calendar-example.rs
+++ b/examples/calendar-example.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
     dotenv().ok();
 
-    let calendar = Calendar::new(GoogleCalendarEventSource::new().await?);
+    let calendar = Calendar::new(GoogleCalendarEventSource::new().await?)?;
     calendar.sync_once().await?;
 
     let now = Zoned::now();

--- a/src/calendar/google/mod.rs
+++ b/src/calendar/google/mod.rs
@@ -10,6 +10,7 @@ use reqwest::{Request, Response};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware, Next};
 use std::ops::Range;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -112,6 +113,7 @@ impl GoogleCalendarClient {
         let client = ClientBuilder::new(
             reqwest::Client::builder()
                 .default_headers(headers)
+                .timeout(Duration::from_secs(10))
                 .build()?,
         )
         .with(AuthMiddleware::new(token_source))

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,53 @@
+use crate::Result;
+use prometheus::{
+    core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge},
+    opts, IntCounterVec, IntGauge, Registry,
+};
+
+pub const NAMESPACE: &str = "wohnzimmer";
+
+/// Container for calendar metrics.
+pub(crate) struct CalendarMetrics {
+    calendar_events: IntGauge,
+    calendar_syncs: IntCounterVec,
+}
+
+impl CalendarMetrics {
+    /// Creates new CalendarMetrics.
+    pub fn new() -> Result<CalendarMetrics> {
+        let calendar_events = IntGauge::with_opts(
+            opts!("calendar_events", "Number of events in the calendar").namespace(NAMESPACE),
+        )?;
+
+        let calendar_syncs = IntCounterVec::new(
+            opts!(
+                "calendar_syncs_total",
+                "Total number of calendar syncs performed"
+            )
+            .namespace(NAMESPACE),
+            &["status"],
+        )?;
+
+        Ok(CalendarMetrics {
+            calendar_events,
+            calendar_syncs,
+        })
+    }
+
+    /// Registers the metrics in a prometheus registry.
+    pub fn register(&self, registry: &Registry) -> Result<()> {
+        registry.register(Box::new(self.calendar_events.clone()))?;
+        registry.register(Box::new(self.calendar_syncs.clone()))?;
+        Ok(())
+    }
+
+    /// Provides access to the calendar events gauge.
+    pub fn calendar_events(&self) -> GenericGauge<AtomicI64> {
+        self.calendar_events.clone()
+    }
+
+    /// Provides access to the calendar syncs counter.
+    pub fn calendar_syncs(&self, status: &str) -> GenericCounter<AtomicU64> {
+        self.calendar_syncs.with_label_values(&[status])
+    }
+}


### PR DESCRIPTION
- Adds a metrics endpoint at `/metrics` if metrics are enabled in the config.
- Metrics endpoint optionally supports Bearer token auth so we can protect it properly when making it public.
- Custom metrics:
  - Custom metric `wohnzimmer_calendar_syncs_total` (counter): increases every time a sync was performed (`status` label with values `success` or `error`).
  - Custom metric `wohnzimmer_calendar_events` (gauge): number of calender events fetched during the last sync (no labels).
- Standard metrics: HTTP metrics and process metrics.

What's left to expose metrics in production (can be a separate PR):

- Production config needs to updated to expose the metrics endpoint. Right now it has `metrics.enabled = false`.
- Configure a Bearer token for the metrics endpoint via the `METRICS__TOKEN` secret via `flyctl` before deploying (we want to make it public so we can monitoring from somewhere else, not via fly.io's prometheus).
