### PR TITLE
feat(metrics): add `calendar_latest_sync_seconds`

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,25 +1,35 @@
 use crate::Result;
 use prometheus::{
     core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge},
-    opts, IntCounterVec, IntGauge, Registry,
+    opts, IntCounterVec, IntGauge, IntGaugeVec, Registry,
 };
 
 pub const NAMESPACE: &str = "wohnzimmer";
 
 /// Container for calendar metrics.
 pub(crate) struct CalendarMetrics {
-    calendar_events: IntGauge,
-    calendar_syncs: IntCounterVec,
+    events: IntGauge,
+    latest_sync_seconds: IntGaugeVec,
+    syncs_total: IntCounterVec,
 }
 
 impl CalendarMetrics {
     /// Creates new CalendarMetrics.
     pub fn new() -> Result<CalendarMetrics> {
-        let calendar_events = IntGauge::with_opts(
+        let events = IntGauge::with_opts(
             opts!("calendar_events", "Number of events in the calendar").namespace(NAMESPACE),
         )?;
 
-        let calendar_syncs = IntCounterVec::new(
+        let latest_sync_seconds = IntGaugeVec::new(
+            opts!(
+                "calendar_latest_sync_seconds",
+                "UNIX timestamp seconds of the latest successful calendar sync"
+            )
+            .namespace(NAMESPACE),
+            &["status"],
+        )?;
+
+        let syncs_total = IntCounterVec::new(
             opts!(
                 "calendar_syncs_total",
                 "Total number of calendar syncs performed"
@@ -29,25 +39,52 @@ impl CalendarMetrics {
         )?;
 
         Ok(CalendarMetrics {
-            calendar_events,
-            calendar_syncs,
+            events,
+            latest_sync_seconds,
+            syncs_total,
         })
     }
 
     /// Registers the metrics in a prometheus registry.
     pub fn register(&self, registry: &Registry) -> Result<()> {
-        registry.register(Box::new(self.calendar_events.clone()))?;
-        registry.register(Box::new(self.calendar_syncs.clone()))?;
+        registry.register(Box::new(self.events.clone()))?;
+        registry.register(Box::new(self.latest_sync_seconds.clone()))?;
+        registry.register(Box::new(self.syncs_total.clone()))?;
         Ok(())
     }
 
     /// Provides access to the calendar events gauge.
-    pub fn calendar_events(&self) -> GenericGauge<AtomicI64> {
-        self.calendar_events.clone()
+    pub fn events(&self) -> GenericGauge<AtomicI64> {
+        self.events.clone()
+    }
+
+    /// Provides access to the latest calendar sync UNIX timestamp gauge.
+    pub fn latest_sync_seconds(&self, status: CalendarSyncStatus) -> GenericGauge<AtomicI64> {
+        self.latest_sync_seconds
+            .with_label_values(&[status.as_str()])
     }
 
     /// Provides access to the calendar syncs counter.
-    pub fn calendar_syncs(&self, status: &str) -> GenericCounter<AtomicU64> {
-        self.calendar_syncs.with_label_values(&[status])
+    pub fn syncs_total(&self, status: CalendarSyncStatus) -> GenericCounter<AtomicU64> {
+        self.syncs_total.with_label_values(&[status.as_str()])
+    }
+}
+
+/// Status of a calendar sync operation.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum CalendarSyncStatus {
+    /// Calendar sync was successful.
+    Success,
+    /// An error occurred while syncing the calendar.
+    Error,
+}
+
+impl CalendarSyncStatus {
+    /// Returns the status as a &str.
+    pub fn as_str(&self) -> &str {
+        match self {
+            CalendarSyncStatus::Success => "success",
+            CalendarSyncStatus::Error => "error",
+        }
     }
 }


### PR DESCRIPTION
This metric contains the UNIX timestamp of the latest successful calendar sync.

Additionally, this change renames a couple of internal fields and methods to make them more concise.